### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Uses the `--help` to build MCP tools.
 
 Works with any CLI tool that has `--help` output.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/eirikb-any-cli-mcp-server).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/eirikb-any-cli-mcp-server).